### PR TITLE
Fix concatenation not working in bash

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -50,7 +50,7 @@ for containerName in $containerNames; do
     # Check if the volume name is not empty
     if [ -n "$volumeName" ]; then
       # Add the volume path to the volume paths string
-      volumePaths+=" /var/lib/docker/volumes/$volumeName"
+      volumePaths="$volumePaths /var/lib/docker/volumes/$volumeName"
     fi
   done
 done


### PR DESCRIPTION
On an Ubuntu server, the migration script was failing showing "Not found" after each volume path, as it was trying to run the path as a command, instead of concatenating.

This concatenation should work better than += in most cases.